### PR TITLE
PRODENG-2847 Provision module fixes

### DIFF
--- a/ingress.tf
+++ b/ingress.tf
@@ -20,14 +20,19 @@ locals {
 
 resource "openstack_lb_loadbalancer_v2" "lb" {
   for_each       = var.ingresses
-  name           = each.key
+  name           = "${var.name}-${each.key}-lb"
   vip_network_id = openstack_networking_network_v2.network[each.value.network_name].id
 }
 
+resource "openstack_networking_floatingip_v2" "instance_fip" {
+  for_each       = {for k, v in var.ingresses: k => v if v.public == true}
+  pool    = var.external_network.fip_pool
+  port_id = openstack_lb_loadbalancer_v2.lb[each.key].vip_port_id
+}
 
 resource "openstack_lb_listener_v2" "lb_listener" {
   for_each        = local.lb_listeners_map
-  name            = "${each.key}-listener"
+  name            = "${each.key}-lb-listener"
   protocol        = each.value.protocol
   protocol_port   = each.value.protocol_port
   loadbalancer_id = openstack_lb_loadbalancer_v2.lb[each.value.ingress_key].id
@@ -66,5 +71,5 @@ resource "openstack_lb_members_v2" "lb_members" {
 // calculated after lb is created
 locals {
   // Add the lb for the lb to the ingress
-  ingresses_withlb = { for k, i in var.ingresses : k => merge(i, openstack_lb_loadbalancer_v2.lb[k]) }
+  ingresses_withlb = { for k, i in var.ingresses : k => merge(i, openstack_lb_loadbalancer_v2.lb[k], {"floating_ip": openstack_networking_floatingip_v2.instance_fip[k].address}) }
 }

--- a/ingress.tf
+++ b/ingress.tf
@@ -6,6 +6,7 @@ locals {
         listener_key  = l_key
         protocol      = l.protocol
         protocol_port = l.protocol_port
+        target_port   = l.target_port
         lb_method     = l.lb_method
         nw_id         = openstack_networking_network_v2.network[ingr.network_name].id
         nodegroups    = ingr.nodegroups
@@ -63,7 +64,7 @@ resource "openstack_lb_members_v2" "lb_members" {
     content {
       name          = member.value["name"]
       address       = member.value["network"][0]["fixed_ip_v4"]
-      protocol_port = each.value.protocol_port
+      protocol_port = each.value.target_port
     }
   }
 }

--- a/modules/key/main.tf
+++ b/modules/key/main.tf
@@ -1,0 +1,9 @@
+resource "tls_private_key" "ed25519" {
+  algorithm = "ED25519"
+}
+
+resource "openstack_compute_keypair_v2" "keypair" {
+  name       = var.name
+  public_key = tls_private_key.ed25519.public_key_openssh
+
+}

--- a/modules/key/outputs.tf
+++ b/modules/key/outputs.tf
@@ -1,0 +1,8 @@
+output "private_key" {
+  description = "Private key contents"
+  value       = tls_private_key.ed25519.private_key_openssh
+}
+
+output "keypair" {
+  value = openstack_compute_keypair_v2.keypair
+}

--- a/modules/key/providers.tf
+++ b/modules/key/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    openstack = {
+      source = "terraform-provider-openstack/openstack"
+    }
+  }
+}

--- a/modules/key/variables.tf
+++ b/modules/key/variables.tf
@@ -1,0 +1,4 @@
+variable "name" {
+  description = "What label to use for the keypair"
+  type        = string
+}

--- a/modules/nodegroups/nodes.tf
+++ b/modules/nodegroups/nodes.tf
@@ -13,6 +13,7 @@ resource "openstack_compute_instance_v2" "instance" {
     }
   }
   tags = var.tags
+  user_data = var.user_data
 }
 
 data "openstack_networking_port_v2" "instance_port" {

--- a/modules/nodegroups/nodes.tf
+++ b/modules/nodegroups/nodes.tf
@@ -34,3 +34,7 @@ resource "openstack_networking_floatingip_v2" "instance_fip" {
   port_id = data.openstack_networking_port_v2.instance_port[count.index].id
   tags    = var.tags
 }
+
+locals {
+  nodes_with_fips = [for instance in openstack_compute_instance_v2.instance : merge(instance, {"floating_ip" : openstack_networking_floatingip_v2.instance_fip[index(openstack_compute_instance_v2.instance, instance)].address})]
+}

--- a/modules/nodegroups/outputs.tf
+++ b/modules/nodegroups/outputs.tf
@@ -1,3 +1,4 @@
 output "nodes" {
-  value = openstack_compute_instance_v2.instance
+  value = local.nodes_with_fips
+  sensitive = false
 }

--- a/modules/nodegroups/variables.tf
+++ b/modules/nodegroups/variables.tf
@@ -51,3 +51,9 @@ variable "public" {
   description = "True if machines need to have FIPs assigned, false otherwise. If true, first attached ntwork's port will be used as port for FIP"
   type        = bool
 }
+
+variable "user_data" {
+  description = "Cloud-init userdata to be passed to the instance"
+  type        = string
+  default     = ""
+}

--- a/network.tf
+++ b/network.tf
@@ -35,7 +35,6 @@ resource "openstack_networking_subnet_v2" "subnet" {
   tags       = concat([var.name, each.key], var.extra_tags)
 }
 
-
 resource "openstack_networking_router_v2" "router" {
   for_each       = local.network_subnets_map
   name           = "${each.key}-router"

--- a/nodes.tf
+++ b/nodes.tf
@@ -14,6 +14,8 @@ module "nodegroups" {
   security_groups = [for k, v in var.securitygroups : "${var.name}-${k}" if contains(v.nodegroups, each.key)]
   tags            = concat([var.name, each.key], var.extra_tags)
   user_data       = each.value.user_data
+
+  depends_on      = [ openstack_networking_subnet_v2.subnet ]
 }
 
 // locals created after node groups are provisioned.

--- a/nodes.tf
+++ b/nodes.tf
@@ -13,6 +13,7 @@ module "nodegroups" {
   networks        = [for k, v in var.networks : "${var.name}-${k}" if contains(v.nodegroups, each.key)]
   security_groups = [for k, v in var.securitygroups : "${var.name}-${k}" if contains(v.nodegroups, each.key)]
   tags            = concat([var.name, each.key], var.extra_tags)
+  user_data       = each.value.user_data
 }
 
 // locals created after node groups are provisioned.

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,3 +8,7 @@ output "ingresses" {
   description = "Created ingress data"
   value       = local.ingresses_withlb
 }
+
+output "subnets" {
+  value = openstack_networking_subnet_v2.subnet
+}

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,7 @@ variable "ingresses" {
   type = map(object({
     nodegroups    = list(string) # which nodegroups should get attached to the ingress
     network_name  = string
+    public        = bool
     listeners     = map(object({
       protocol      = string
       protocol_port = number

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,7 @@ variable "nodegroups" {
     count        = number
     role         = string
     public       = bool #if public, then floating IP will be assigned
+    user_data    = optional(string)
     #    tags                  = optional(map(string), {})
   }))
   default = {}

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,7 @@ variable "ingresses" {
     listeners     = map(object({
       protocol      = string
       protocol_port = number
+      target_port   = number
       lb_method     = string
     }))
   }))


### PR DESCRIPTION
- Add key helper module to create SSH keys
- Add the ability to assign FIP to LB in order to access it from internet
- Add the ability to specify cloud-init's userdata
- Add nodes FIPs to nodegroups submodule output